### PR TITLE
`Redis.from_Url(decode_components=True)`

### DIFF
--- a/pgsync/checkpoint.py
+++ b/pgsync/checkpoint.py
@@ -72,7 +72,10 @@ class RedisCheckpoint:
         namespace = settings.CHECKPOINT_REDIS_NAMESPACE
         self._key = f"{namespace}:{name}"
         self._redis = Redis.from_url(
-            url=url, socket_timeout=settings.REDIS_SOCKET_TIMEOUT, decode_responses=True
+            url=url,
+            socket_timeout=settings.REDIS_SOCKET_TIMEOUT,
+            decode_components=True,
+            decode_responses=True,
         )
 
     def validate(self) -> None:

--- a/pgsync/redisqueue.py
+++ b/pgsync/redisqueue.py
@@ -23,6 +23,7 @@ class RedisQueue(object):
         try:
             self.__db: Redis = Redis.from_url(
                 url,
+                decode_components=True,
                 socket_timeout=REDIS_SOCKET_TIMEOUT,
             )
             self.__db.ping()


### PR DESCRIPTION
Our old friend the urlencoded password strikes again.