### PR TITLE
Bootstrap is idempotent

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -35,6 +35,13 @@ logger = logging.getLogger(__name__)
     default=False,
     help="Turn on verbosity",
 )
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Force creation of triggers and replication slots",
+)
 def main(
     teardown: bool,
     config: str,
@@ -43,6 +50,7 @@ def main(
     host: str,
     port: int,
     verbose: bool,
+    force: bool,
 ) -> None:
     """Application onetime Bootstrap."""
     kwargs: dict = {
@@ -75,8 +83,12 @@ def main(
         if teardown:
             sync.teardown()
             continue
-        sync.setup()
-        logger.info(f"Bootstrap: {sync.database}")
+
+        if force or sync.bootstrap_required:
+            sync.setup()
+            logger.info(f"Bootstrap: {sync.database}")
+        else:
+            logger.info(f"Index {sync.index} exists. Skipping bootstrap.")
 
 
 if __name__ == "__main__":

--- a/pgsync/search_client.py
+++ b/pgsync/search_client.py
@@ -84,6 +84,9 @@ class SearchClient(object):
         """Close transport connection."""
         self.__client.transport.close()
 
+    def exists(self, index: str) -> bool:
+        return self.__client.indices.exists(index)
+
     def teardown(self, index: str) -> None:
         """
         Teardown the Elasticsearch/OpenSearch index.
@@ -270,7 +273,7 @@ class SearchClient(object):
         """Create Elasticsearch/OpenSearch setting and mapping if required."""
         body: dict = defaultdict(lambda: defaultdict(dict))
 
-        if not self.__client.indices.exists(index=index):
+        if not self.exists(index=index):
             if setting:
                 body.update(**{"settings": {"index": setting}})
             if mappings:

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -249,6 +249,14 @@ class Sync(Base, metaclass=Singleton):
             routing=self.routing,
         )
 
+    @property
+    def bootstrap_required(self) -> bool:
+        """
+        Use the existence of the index in opensearch as a proxy to determine whether we actually have
+        to bootstrap stuff.
+        """
+        return self.search_client.exists(self.index)
+
     def setup(self) -> None:
         """Create the database triggers and replication slot."""
 


### PR DESCRIPTION
This PR makes sure that the pgsync bootstrap command is idempotent.

As a (bad) proxy, we check the existence of the index in Opensearch and only run the bootstrap code if it's not there. 