### PR TITLE
Adapted handling of replication slot check

### DIFF
--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -139,7 +139,7 @@ class Sync(Base, metaclass=Singleton):
                 "Enable logical decoding by setting wal_level = logical"
             )
 
-        self._can_create_replication_slot("_tmp_")
+        self._can_create_replication_slot()
 
         rds_logical_replication: t.Optional[str] = self.pg_settings(
             "rds.logical_replication"


### PR DESCRIPTION
Right now, we check replication slots by creating and dropping them on every sync. But when pgsync runs in concurrent mode, there's a chance two processes try to drop the same slot at the same time, which can cause the sync to fail.

To make this safer (and avoid constantly creating/dropping slots), we now just do a simple SELECT to check if the user has permission to create replication slots.