### PR TITLE
Handle only the requested schemas

### DIFF
--- a/pgsync/base.py
+++ b/pgsync/base.py
@@ -172,14 +172,9 @@ class Base(object):
         "varchar",
     )
 
-    def __init__(
-        self, database: str, verbose: bool = False, *args, **kwargs
-    ) -> None:
+    def __init__(self, database: str, verbose: bool = False, *args, **kwargs) -> None:
         """Initialize the base class constructor."""
-        self.__engine: sa.engine.Engine = _pg_engine(
-            database, echo=False, **kwargs
-        )
-        self.__schemas: t.Optional[dict] = None
+        self.__engine: sa.engine.Engine = _pg_engine(database, echo=False, **kwargs)
         # models is a dict of f'{schema}.{table}'
         self.__models: dict = {}
         self.__metadata: dict = {}
@@ -299,16 +294,6 @@ class Base(object):
     def engine(self) -> sa.engine.Engine:
         """Get the database engine."""
         return self.__engine
-
-    @property
-    def schemas(self) -> dict:
-        """Get the database schema names."""
-        if self.__schemas is None:
-            self.__schemas = sa.inspect(self.engine).get_schema_names()
-            for schema in BUILTIN_SCHEMAS:
-                if schema in self.__schemas:
-                    self.__schemas.remove(schema)
-        return self.__schemas
 
     def views(self, schema: str) -> list:
         """Get all materialized and non-materialized views."""

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -175,10 +175,8 @@ class Sync(Base, metaclass=Singleton):
                         f"{MATERIALIZED_VIEW}. Please re-run bootstrap."
                     )
 
-            if node.schema not in self.schemas:
-                raise InvalidSchemaError(
-                    f"Unknown schema name(s): {node.schema}"
-                )
+            if node.schema not in self.tree.schemas:
+                raise InvalidSchemaError(f"Unknown schema name(s): {node.schema}")
 
             # ensure all base tables have at least one primary_key
             for table in node.base_tables:
@@ -263,7 +261,7 @@ class Sync(Base, metaclass=Singleton):
         join_queries: bool = settings.JOIN_QUERIES
         self.teardown(drop_view=False)
 
-        for schema in self.schemas:
+        for schema in self.tree.schemas:
             self.create_function(schema)
             tables: t.Set = set()
             # tables with user defined foreign keys
@@ -308,7 +306,7 @@ class Sync(Base, metaclass=Singleton):
         self._checkpoint.teardown()
         self.redis.delete()
 
-        for schema in self.schemas:
+        for schema in self.tree.schemas:
             tables: t.Set = set()
             for node in self.tree.traverse_breadth_first():
                 tables |= set(


### PR DESCRIPTION
For whatever reason the triggers were being set up in every schema that exists in the database. Instead, only the schemas provided in the index config should be considered. Luckily the code is somewhat there already: `self.tree.schemas` should be a set of all schemas defined in the index config, or `{"public"}` as default.