### PR TITLE
Do not check replication permissions

### DIFF
--- a/pgsync/base.py
+++ b/pgsync/base.py
@@ -208,32 +208,6 @@ class Base(object):
         except (TypeError, IndexError):
             return None
 
-    def _can_create_replication_slot(self) -> None:
-        """Check if the current PostgreSQL user has privileges to manage replication slots."""
-        user = self.engine.url.username
-
-        try:
-            with self.engine.connect() as conn:
-                result = conn.execute(
-                    sa.text(
-                        "SELECT rolreplication FROM pg_roles WHERE rolname = current_user"
-                    )
-                ).scalar()
-
-                if not result:
-                    raise ReplicationSlotError(
-                        f'PG_USER "{user}" does not have REPLICATION privileges. '
-                        f"This is required to create and drop replication slots."
-                    )
-
-        except Exception as e:
-            logger.exception(
-                f"Error checking replication privileges for user {user}: {e}"
-            )
-            raise ReplicationSlotError(
-                f'Failed to verify replication privileges for user "{user}".\n{e}'
-            )
-
     # Tables...
     def models(self, table: str, schema: str) -> sa.sql.Alias:
         """Get an SQLAlchemy model representation from a table.

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -135,19 +135,12 @@ class Sync(Base, metaclass=Singleton):
 
         wal_level: t.Optional[str] = self.pg_settings("wal_level")
         if not wal_level or wal_level.lower() != "logical":
-            raise RuntimeError(
-                "Enable logical decoding by setting wal_level = logical"
-            )
-
-        self._can_create_replication_slot()
+            raise RuntimeError("Enable logical decoding by setting wal_level = logical")
 
         rds_logical_replication: t.Optional[str] = self.pg_settings(
             "rds.logical_replication"
         )
-        if (
-            rds_logical_replication
-            and rds_logical_replication.lower() == "off"
-        ):
+        if rds_logical_replication and rds_logical_replication.lower() == "off":
             raise RDSError("rds.logical_replication is not enabled")
 
         if self.index is None:


### PR DESCRIPTION
This doesn't and won't work in RDS since it doesn't manage replication permissions through the `REPLICATION` role attribute.
We also never noticed because the version of pgsync `main` does not get magically installed in `alasco-app`, one needs an explicit `uv sync --upgrade-package pgsync` to pull new commits (https://github.com/alasco-tech/alasco-app/pull/21944).

Just drop the check and let it fail whenever it has to fail, do not ask for permission.