### PR TITLE
Create indicies only if they not exist

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -85,6 +85,9 @@ def main(
             continue
 
         if force or sync.bootstrap_required:
+            # Create all indicies
+            sync.create_setting()
+            # Create all triggers and replication slots
             sync.setup()
             logger.info(f"Bootstrap: {sync.database}")
         else:

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -103,7 +103,6 @@ class Sync(Base, metaclass=Singleton):
         self.tree: Tree = Tree(self.models, nodes=self.nodes)
         if validate:
             self.validate(repl_slots=repl_slots)
-            self.create_setting()
         if self.plugins:
             self._plugins: Plugins = Plugins("plugins", self.plugins)
         self.query_builder: QueryBuilder = QueryBuilder(verbose=verbose)


### PR DESCRIPTION
The index creation runs while `pgsync` is initialized, which creates the index causing the check to always return true. Moved the call outside of `pgsync` initialisation to ensure expected behaviour.