### PR TITLE
INT-683: `Sync.setup` as the bootstrap entrypoint

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 """PGSync bootstrap."""
+
 import logging
 
 import click
@@ -84,14 +85,7 @@ def main(
             sync.teardown()
             continue
 
-        if force or sync.bootstrap_required:
-            # Create all indicies
-            sync.create_setting()
-            # Create all triggers and replication slots
-            sync.setup()
-            logger.info(f"Bootstrap: {sync.database}")
-        else:
-            logger.info(f"Index {sync.index} exists. Skipping bootstrap.")
+        sync.setup(force=force)
 
 
 if __name__ == "__main__":

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -239,16 +239,14 @@ class Sync(Base, metaclass=Singleton):
             routing=self.routing,
         )
 
-    @property
-    def bootstrap_required(self) -> bool:
-        """
-        Use the existence of the index in opensearch as a proxy to determine whether we actually have
-        to bootstrap stuff.
-        """
-        return not self.search_client.exists(self.index)
-
-    def setup(self) -> None:
+    def setup(self, force: bool = False) -> None:
         """Create the database triggers and replication slot."""
+
+        if not force and self.search_client.exists(self.index):
+            logger.info(f"Index {self.index} exists. Skipping setup.")
+            return
+
+        self.create_setting()
 
         join_queries: bool = settings.JOIN_QUERIES
         self.teardown(drop_view=False)


### PR DESCRIPTION
Keep the logic out of the `bootstrap` script so we can stop calling it eventually.